### PR TITLE
add back accidentally removed npm start script

### DIFF
--- a/.github/workflows/add-testing.yml
+++ b/.github/workflows/add-testing.yml
@@ -1,0 +1,11 @@
+name: Run Tests
+on: [push]
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Install dependencies
+              run: npm install
+            - name: "Run Test"
+              run: npm test

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "web-vitals": "^2.1.2"
   },
   "scripts": {
+    "start": "react-scripts start",
     "test": "mocha"
   },
   "eslintConfig": {


### PR DESCRIPTION
On a previous commit, I accidentally removed the `npm start` script. This PR adds that back. 

It also renames the Github Actions file and creates an empty file to add serverside code.